### PR TITLE
Added build.rs file to avoid clang linker throwing symbols error

### DIFF
--- a/crate/build.rs
+++ b/crate/build.rs
@@ -1,0 +1,5 @@
+extern crate napi_build;
+
+fn main() {
+  napi_build::setup();
+}


### PR DESCRIPTION
Added `build.rs` file to avoid clang linker (invoked be rustc)  throwing ***clang: error: linker command failed with exit code 1 ***

### Resolution
1. Include `build.rs` in create directory
2. This pattern can be found in the `https://github.com/napi-rs/package-template` example
3. Further discussion on this issue found in the README of `https://github.com/napi-rs/napi-rs`

### Steps to reproduce
1. Use current repo version without ***`build.rs`***
4. Invoke `yarn build` or `cargo build` (from crate directory)
5. Observe error output (example below)

Invoking using cargo build
```bash
(base) ➜  crate git:(main) ✗ cargo build
   Compiling proc-macro2 v1.0.34
   Compiling unicode-xid v0.2.2
```

Snippet just as error is thrown
```bash
   Compiling napi v2.0.2
   Compiling minenode v0.0.1 (/Users/cconnolly/Development/minenode/crate)
error: linking with `cc` failed: exit status: 1
```

Tail end of error from clang linker
```bash
            "_napi_get_value_bigint_words", referenced from:
                _$LT$napi..bindgen_runtime..js_values..bigint..BigInt$u20$as$u20$napi..bindgen_runtime..js_values..FromNapiValue$GT$::from_napi_value::h658c1da7b6e34c07 in libnapi-c79228d985dc1719.rlib(napi-c79228d985dc1719.napi.21bc4114-cgu.14.rcgu.o)
          ld: symbol(s) not found for architecture arm64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```